### PR TITLE
This commit introduces two main improvements to resolve the "503 Serv…

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,14 +19,18 @@ const dbConfig = require('./config/db.config');
 
 // Prioritize MongoDB Atlas connection from environment variables
 let connectionURL;
-if (process.env.MONGODB_HOST) {
-  // Use MongoDB Atlas connection
+if (process.env.MONGODB_URI) {
+  // Use MongoDB Atlas connection from MONGODB_URI
+  connectionURL = process.env.MONGODB_URI;
+  console.log('Using MongoDB Atlas connection from MONGODB_URI');
+} else if (process.env.MONGODB_HOST) {
+  // Use MongoDB Atlas connection from separate host/db variables
   connectionURL = process.env.MONGODB_HOST;
   if (!connectionURL.endsWith('/')) {
     connectionURL += '/';
   }
   connectionURL += process.env.MONGODB_DB || dbConfig.DB;
-  console.log('Using MongoDB Atlas connection');
+  console.log('Using MongoDB Atlas connection from MONGODB_HOST');
 } else {
   // Fallback to local MongoDB connection
   connectionURL = `mongodb://${dbConfig.HOST}:${dbConfig.PORT}/${dbConfig.DB}`;


### PR DESCRIPTION
…ice Unavailable" error.

First, it prevents the server from crashing when it fails to connect to the database by commenting out the `process.exit(1)` call in the error handler. This makes the application more resilient to database outages.

Second, it updates the server's connection logic to correctly handle a `MONGODB_URI` environment variable, allowing for a standard connection to MongoDB Atlas.

With this change, the application is now configured to connect to the user's Atlas cluster. The final step required is for the user to whitelist the server's IP address in their MongoDB Atlas dashboard.