### PR TITLE
Fix: Correct MongoDB connection settings for standalone instance

### DIFF
--- a/config/db.config.js
+++ b/config/db.config.js
@@ -3,14 +3,10 @@ module.exports = {
   PORT: 27017,
   DB: "freshshare_db",
   options: {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
     serverSelectionTimeoutMS: 30000,
     autoIndex: true,
     maxPoolSize: 10,
     socketTimeoutMS: 45000,
-    family: 4,
-    retryWrites: true,
-    w: "majority"
+    family: 4
   }
 };


### PR DESCRIPTION
The server was configured with `retryWrites: true` and `w: "majority"`, which are options for a MongoDB replica set. When connecting to a standalone instance, these options cause the connection to fail.

This commit removes the incompatible options from `config/db.config.js`. It also removes the deprecated `useNewUrlParser` and `useUnifiedTopology` options. This should resolve the 503 Service Unavailable errors caused by the database connection failure.