### PR TITLE
Fix(server): Improve MongoDB Atlas connection logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ if (process.env.MONGODB_URI) {
 // Connect to MongoDB with better error handling
 console.log('Attempting to connect to MongoDB...', {
   connectionString: connectionURL ? 'Configured' : 'Missing',
-  usingAtlas: process.env.MONGODB_HOST ? true : false
+  usingAtlas: !!(process.env.MONGODB_URI || process.env.MONGODB_HOST)
 });
 
 mongoose.connect(connectionURL, dbConfig.options)


### PR DESCRIPTION
The logging statement for the database connection did not correctly detect when a `MONGODB_URI` was being used. This could lead to confusing logs where the application was using an Atlas connection but logging `usingAtlas: false`.

This commit updates the logic to check for both `MONGODB_URI` and `MONGODB_HOST` environment variables when determining the value of `usingAtlas` in the log message.